### PR TITLE
Add summary of playlist rules into playlist description

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -141,7 +141,7 @@ function syncPlaylist(playlist, attempt) {
 
 function renameAndSync(playlist) {
   console.log('renaming to', playlist.title);
-  Gm.updatePlaylist(userIndexForId(playlist.userId), playlist.remoteId, playlist.title, () => {
+  Gm.updatePlaylist(userIndexForId(playlist.userId), playlist.remoteId, playlist.title, playlist, () => {
     syncPlaylist(playlist);
   });
 }


### PR DESCRIPTION
This commit adds a summary of the playlist rule into the description, so it appears as something like this:

> Automatically managed by Autoplaylists for Google Music™ (durationMillis > 180000 and durationMillis < 240000 and (title matches blue or title matches green or artist = Kwyjibo)) sort by title descending

I find it useful to have this available, so I can keep track of my many playlists. Maybe others will find it useful too.

BTW I love this extension. Thanks for writing it -- It fills a glaring hole in Google Music.