### PR TITLE
Added ability to query within a month for datetimes

### DIFF
--- a/src/js/track.js
+++ b/src/js/track.js
@@ -28,6 +28,7 @@ exports.operators = {
   datetime: [
     {name: 'lt', label: 'earlier than', input_type: 'text'},
     {name: 'gt', label: 'between now and', input_type: 'text'},
+    {name: 'in-month', label: 'in the month of', input_type: 'text'},
   ],
   select: [
     {label: 'is equal to', name: 'equalTo', input_type: 'select'},
@@ -157,7 +158,7 @@ exports.fields = [
   f([24, 'creationDate', Lf.Type.INTEGER], {
     sjName: 'creationTimestamp',
     label: 'date added to library',
-    explanation: 'either a relative datetime like "30 days ago" or an absolute one like "April 1 2016".',
+    explanation: 'either a relative datetime like "30 days ago", an absolute one like "April 1 2016", or a month like "2017-02".',
     is_datetime: true,
     // coerce strings (sj)
     coerce: val => parseInt(val, 10),

--- a/src/js/trackcache.js
+++ b/src/js/trackcache.js
@@ -176,6 +176,14 @@ function buildWhereClause(track, playlistsById, splaylistcache, resultCache, db,
     if (Track.fieldsByName[rule.name].is_datetime) {
       value = Date.create(rule.value).getTime() * 1000;
     }
+    if (rule.operator === 'in-month') {
+      // We want a specific month; we basically want dates between the specified value and a month from it
+      // FIXME: ideally, we should check that the start value is a 1st of a month at midnight
+      var valueStart = value;
+      var valueEnd = Date.create(rule.value).advance({ month: 1 }).getTime() * 1000;
+      clause = track[rule.name]['between'](valueStart, valueEnd);
+      return Promise.resolve(clause);
+    }
 
     if (rule.operator === 'match') {
       operator = 'match';

--- a/src/js/trackcache.js
+++ b/src/js/trackcache.js
@@ -179,9 +179,9 @@ function buildWhereClause(track, playlistsById, splaylistcache, resultCache, db,
     if (rule.operator === 'in-month') {
       // We want a specific month; we basically want dates between the specified value and a month from it
       // FIXME: ideally, we should check that the start value is a 1st of a month at midnight
-      var valueStart = value;
-      var valueEnd = Date.create(rule.value).advance({ month: 1 }).getTime() * 1000;
-      clause = track[rule.name]['between'](valueStart, valueEnd);
+      const valueStart = value;
+      const valueEnd = Date.create(rule.value).advance({ month: 1 }).getTime() * 1000;
+      clause = track[rule.name].between(valueStart, valueEnd);
       return Promise.resolve(clause);
     }
 


### PR DESCRIPTION
With minimal testing on a test library combined with my minimal Chrome extension development knowledge, I _believe_ that this change adds the ability to target library addition date within a month.