### PR TITLE
Using the local (node_modules) watchify

### DIFF
--- a/watch.sh
+++ b/watch.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+PATH+=:node_modules/.bin
+
 for f in src/js/*.js; do
-    node_modules/.bin/watchify "$f" -d -o "src/js-built/$(basename $f)" -v &
+    watchify "$f" -d -o "src/js-built/$(basename $f)" -v &
 done
 
 wait $!

--- a/watch.sh
+++ b/watch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 for f in src/js/*.js; do
-    watchify "$f" -d -o "src/js-built/$(basename $f)" -v &
+    node_modules/.bin/watchify "$f" -d -o "src/js-built/$(basename $f)" -v &
 done
 
 wait $!


### PR DESCRIPTION
Given that watchify is pulled by npm install, uses the version under node_modules in case there is no global version available.